### PR TITLE
chore: Final documentation sanitization (Project1/Project2 pattern)

### DIFF
--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -25,6 +25,9 @@ Aether does not re-index the entire project on every change. Instead, it uses th
 3.  **Surgical Update:** Only files that have been added or modified since the last sync are embedded via the Google Gemini API.
 4.  **Purge:** Any nodes associated with deleted files are automatically removed from the vector index.
 
+Example Flow:
+`Syncing /path/to/project -> /path/to/aether/data/storage/project`
+
 ## 3. Performance & Lazy Loading
 Aether is optimized for a "Zero-Impact" background presence:
 *   **Sleep Mode:** The vector index is NOT loaded into RAM upon server start.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -17,6 +17,9 @@ Cairn prefixes each log line with the project name and the functional module to 
 *   `[aether] [aether.api]` - Server lifecycles and endpoint requests.
 *   `[aether] [aether.stats]` - Logical index reporting.
 
+Example:
+`[INFO] [aether] [aether.watcher] - Watching <ProjectName> at <Path>`
+
 ## 3. Common Troubleshooting
 
 ### `429 RESOURCE_EXHAUSTED` (Google API Quota)

--- a/docs/REGISTRY.md
+++ b/docs/REGISTRY.md
@@ -9,8 +9,8 @@ The source of truth for all tracked contexts. This file is automatically updated
 ### Schema
 ```json
 {
-    "ProjectName": "/absolute/path/to/project",
-    "Vanguard": "/absolute/path/to/Vanguard"
+    "Project1": "/absolute/path/to/project1",
+    "Project2": "/absolute/path/to/project2"
 }
 ```
 


### PR DESCRIPTION
### Strategic Intent
Adopt a generic project identifier pattern and eliminate all remaining machine-specific paths from the technical documentation vault.

### Technical Scope
- Implemented Project1/Project2 schema examples in REGISTRY.md.
- Generalized sync flow examples in ENGINE.md.
- Generalized log examples in OBSERVABILITY.md.
- Verified 100% path privacy.