### PR TITLE
Update OBSERVABILITY.md to remove trademark symbol

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,16 +1,16 @@
 # Aether | Observability & Troubleshooting
 
 ## Overview
-Aether uses a professional telemetry stack to ensure that all background activities are auditable. This system is managed by the **[Cairn](https://github.com/ChadHuckeba/SurvivalStack-Cairn)® Logging Authority**.
+Aether uses a professional telemetry stack to ensure that all background activities are auditable. This system is managed by SurvivalStack **[Cairn](https://github.com/ChadHuckeba/SurvivalStack-Cairn)® Logging Authority**.
 
 ## 1. Log Locations
 *   **Primary Log:** `logs/aether.log`
-    *   Captured by Cairn®. Contains all ingestion events, API calls, and errors.
+    *   Captured by Cairn. Contains all ingestion events, API calls, and errors.
 *   **Startup Log:** `logs/startup.log`
     *   Captured by `session.sh`. Contains initial environment checks and Uvicorn server logs.
 
 ## 2. Functional Hierarchy
-Cairn® prefixes each log line with the project name and the functional module to provide instant context.
+Cairn prefixes each log line with the project name and the functional module to provide instant context.
 
 *   `[aether] [aether.watcher]` - Events from the filesystem sentinel.
 *   `[aether] [aether.ingest]` - Metadata scans and embedding tasks.


### PR DESCRIPTION
Removed the registered trademark symbol from Cairn in the documentation for clarity.