### PR TITLE
refactor: Remove redundant header from Aether GEMINI.md

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,19 +1,3 @@
-# GEMINI GOVERNANCE ARCHITECTURE
-# This file governs the "WHAT" and "WHY" (Policies, Mandates, and Strategic Intent).
-# The "HOW" (Procedural Logic, CLI Flags, and Implementation Steps) is strictly reserved for SKILLS.
-
-## Instruction Hierarchy & Paths
-- **Global Policy (What/Why):** `~/.gemini/GEMINI.md` (Symlinked to `~/core/dotfiles/gemini/GEMINI.md`)
-- **Project Policy (What/Why):** `<project-root>/GEMINI.md`
-- **Global Skills Vault (How):** `~/core/dotfiles/gemini/skills-library/` (Canonical source)
-- **Active Global Skills:** `~/.gemini/skills/` (Symlinks from vault)
-- **Project Skills (How):** `<project-root>/.gemini/skills/` (Project-specific tools)
-
-## Role Distinction
-- **Global File:** Ecosystem-wide mandates, security policies, and governance standards.
-- **Project File:** Localized architectural truth, specialized mandates, and project-specific strategic guardrails.
-- **Skills:** Specialized, on-demand intelligence that provides the technical "How" for specific tools (e.g., gh, git, ruff) to keep the context window lean.
-
 # AETHER: AGENT GOVERNANCE & PROTOCOLS
 
 ## 1.0 SUPREMACY & AUTHORITY


### PR DESCRIPTION
### Strategic Intent
Enforce Single Source of Truth for governance headers by removing the redundant 'Universal Header Block' from Aether GEMINI.md.

### Technical Scope
- **Aether GEMINI.md Update:** Removed the duplicated 'GEMINI GOVERNANCE ARCHITECTURE' and 'Role Distinction' sections.

### Verification Evidence
- **Manual Review:** Confirmed that the Aether GEMINI.md now starts directly with Aether-specific governance, relying on the Global file for structural policy.

### Known Limitations
- None.

Ref #91, #87 (Core-dotfiles)
