### PR TITLE
fix: resolve FastMCP server name case mismatch preventing tool registration. Ref #43

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -8,7 +8,7 @@ AETHER_BASE_URL = os.getenv("AETHER_BASE_URL", "http://localhost:8000")
 TIMEOUT = 30.0
 
 # Initialize MCP Server
-mcp = FastMCP("Aether")
+mcp = FastMCP("aether")
 
 async def call_aether(endpoint: str, method: str = "POST", json: dict = None):
     """Internal helper to handle Aether API calls with error handling."""


### PR DESCRIPTION
### Strategic Intent
This Pull Request resolves a case-sensitivity mismatch where the FastMCP server was initialized with the name `"Aether"` (uppercase), while the configuration key in `mcp_config.json` was defined as `"aether"` (lowercase). This mismatch prevented the client runtime from registering or enabling the server's semantic tools (`query_codebase` and `refresh_index`).

### Technical Scope
- Normalize the `FastMCP` initialization in [mcp_server.py](file:///home/chadh/survivaltools/Aether/mcp_server.py) to lowercase: `mcp = FastMCP("aether")`.
- Aligns case with the canonical lowercase `aether` config key.

### Verification Evidence
- Verified that Aether runs successfully with the change.
- The change matches the strategic intent of Issue #43.

### Known Limitations
- None.

Ref #43
