### PR TITLE
fix: use filename_as_id=True in SimpleDirectoryReader. Ref #50

### DIFF
--- a/src/aether/core/ingest.py
+++ b/src/aether/core/ingest.py
@@ -22,14 +22,12 @@ def sync_local_dir_custom(dir_path: str, storage_dir: str):
     reader = SimpleDirectoryReader(
         input_dir=dir_path,
         recursive=True,
+        filename_as_id=True,
         exclude=["node_modules", ".git", "__pycache__", "venv", ".venv", "storage"],
         required_exts=REQUIRED_EXTS
     )
     
     documents = reader.load_data()
-    for doc in documents:
-        if doc.metadata and "file_path" in doc.metadata:
-            doc.doc_id = doc.metadata["file_path"]
 
     if docstore_exists:
         logger.info("Existing index found. Refreshing changed documents...")


### PR DESCRIPTION
### Strategic Intent
Fix the issue where SimpleDirectoryReader generates UUID doc_ids by default. These UUIDs lead to document hashes being stored under different IDs than the ones looked up by `refresh_ref_docs` (which uses the file path), causing change detection and incremental refreshes to fail silently.

### Technical Scope
- Modified `src/aether/core/ingest.py` to instantiate `SimpleDirectoryReader` with `filename_as_id=True`.
- Removed the redundant post-load loop that reassigned `doc_id` to the file path, as `filename_as_id=True` now does this natively at load time before hashing.

### Verification Evidence
- Verification will be conducted post-merge by wiping the storage folder (`rm -rf ~/survivaltools/Aether/data/storage/vanguard`) and triggering an ingestion to rebuild the index from scratch.
- Subsequent ingestion triggers will be monitored to confirm "No changes detected" instead of re-indexing or ignoring updates.

### Known Limitations
- None.
