### PR TITLE
chore: disable automatic ingest triggering in Aether. Ref #52

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -38,7 +38,18 @@ async def query_codebase(prompt: str) -> str:
     - Use this proactively to understand module behavior, architecture, dependencies, or recent changes.
     """
     result = await call_aether("/query", json={"prompt": prompt})
-    return result.get("response") or result.get("error", "Unknown error")
+    response_text = result.get("response") or result.get("error", "Unknown error")
+    
+    # Prepend warning if there are pending changes in stats
+    try:
+        stats = await call_aether("/stats", method="GET")
+        if isinstance(stats, dict) and stats.get("sync_status", {}).get("pending_changes") is True:
+            warning = "[Warning: index has pending changes — run refresh_index before relying on this result]\n\n"
+            response_text = warning + response_text
+    except Exception:
+        pass
+        
+    return response_text
 
 @mcp.tool()
 async def refresh_index() -> str:

--- a/src/aether/api/app.py
+++ b/src/aether/api/app.py
@@ -24,10 +24,27 @@ from aether.ui.templates import get_dashboard_html, get_manage_html
 logger = logging.getLogger("aether.api")
 PROJECTS = load_projects()
 active_project = list(PROJECTS.keys())[0] if PROJECTS else "None"
-sync_status = {"status": "idle", "last_sync": "Never", "auto_sync": True}
+sync_status = {
+    "status": "idle",
+    "last_sync": "Never",
+    "auto_sync": False,
+    "pending_changes": False,
+    "last_ingested": None
+}
 _cached_index = None
 _stats_cache = {}
 observer = None
+
+def get_project_path(name: str) -> Optional[str]:
+    entry = PROJECTS.get(name)
+    if isinstance(entry, dict):
+        return entry.get("path")
+    return entry
+
+def mark_pending_changes():
+    global sync_status
+    sync_status["pending_changes"] = True
+    logger.info(f"Pending changes flagged by watcher callback for project: {active_project}")
 
 # --- Lifespan Management ---
 
@@ -40,16 +57,18 @@ def restart_watcher():
         except:
             pass
     
-    project_path = PROJECTS.get(active_project)
-    if project_path and os.path.exists(project_path) and sync_status["auto_sync"]:
+    project_path = get_project_path(active_project)
+    if project_path and os.path.exists(project_path):
         observer = setup_watcher(
             path=project_path,
             loop=asyncio.get_event_loop(),
             on_modified_callback=trigger_auto_sync,
-            required_exts=REQUIRED_EXTS
+            required_exts=REQUIRED_EXTS,
+            auto_sync=sync_status["auto_sync"],
+            on_change_detected_callback=mark_pending_changes
         )
         if observer:
-            logger.info(f"Watching {active_project} at {project_path}")
+            logger.info(f"Watching {active_project} at {project_path} (auto_sync={sync_status['auto_sync']})")
 
 async def trigger_auto_sync():
     """Callback for watcher."""
@@ -57,8 +76,14 @@ async def trigger_auto_sync():
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    global PROJECTS, sync_status
     if not os.getenv("GEMINI_API_KEY"):
         logger.error("CRITICAL ERROR: GEMINI_API_KEY is not set.")
+    
+    # Read last_ingested on startup
+    active_entry = PROJECTS.get(active_project)
+    if isinstance(active_entry, dict):
+        sync_status["last_ingested"] = active_entry.get("last_ingested")
     
     restart_watcher()
     yield
@@ -77,10 +102,33 @@ async def run_ingestion_task():
         
     sync_status["status"] = "syncing"
     try:
-        path = PROJECTS[active_project]
-        result = await run_ingestion(active_project, path)
+        path = get_project_path(active_project)
+        exclude_dirs = []
+        if active_project in PROJECTS:
+            entry = PROJECTS[active_project]
+            if isinstance(entry, dict):
+                exclude_dirs = entry.get("exclude_dirs", [])
+        result = await run_ingestion(active_project, path, exclude_dirs)
         sync_status.update(result)
         _cached_index = None # Invalidate cache
+        
+        # Reset pending changes
+        sync_status["pending_changes"] = False
+        
+        # Get UTC ISO 8601 timestamp
+        from datetime import datetime
+        utc_ts = datetime.utcnow().isoformat() + "Z"
+        sync_status["last_ingested"] = utc_ts
+        
+        # Update projects.json entry
+        if active_project in PROJECTS:
+            entry = PROJECTS[active_project]
+            if isinstance(entry, dict):
+                entry["last_ingested"] = utc_ts
+            else:
+                PROJECTS[active_project] = {"path": entry, "last_ingested": utc_ts}
+            save_projects(PROJECTS)
+            
     except Exception as e:
         logger.error(f"Ingestion error: {e}")
         sync_status["status"] = f"error: {str(e)}"
@@ -114,24 +162,33 @@ async def query_endpoint(request: QueryRequest):
 
 @app.post("/switch")
 async def switch_project(request: SwitchRequest):
-    global active_project, _cached_index
+    global active_project, _cached_index, sync_status
     if request.name not in PROJECTS:
         raise HTTPException(status_code=404, detail="Project not found")
     
     active_project = request.name
     _cached_index = None 
     gc.collect()
+    
+    # Read last_ingested for the new active project
+    active_entry = PROJECTS.get(active_project)
+    if isinstance(active_entry, dict):
+        sync_status["last_ingested"] = active_entry.get("last_ingested")
+    else:
+        sync_status["last_ingested"] = None
+    sync_status["pending_changes"] = False
+    
     restart_watcher()
     return {"active": active_project}
 
 @app.get("/projects")
 async def get_projects_endpoint():
-    return get_project_list(PROJECTS)
+    return [{"name": k, "path": (v.get("path") if isinstance(v, dict) else v)} for k, v in PROJECTS.items()]
 
 @app.post("/projects")
 async def add_project_endpoint(request: ProjectConfig):
     global PROJECTS
-    PROJECTS[request.name] = request.path
+    PROJECTS[request.name] = {"path": request.path, "last_ingested": None, "exclude_dirs": []}
     save_projects(PROJECTS)
     return {"status": "added"}
 
@@ -169,7 +226,7 @@ async def get_stats():
         if active_project not in PROJECTS:
             return {"error": "No active project", "available_projects": list(PROJECTS.keys())}
 
-        project_path = PROJECTS.get(active_project)
+        project_path = get_project_path(active_project)
         storage_dir = get_storage_path(active_project)
         docstore_path = storage_dir / "docstore.json"
         

--- a/src/aether/core/engine.py
+++ b/src/aether/core/engine.py
@@ -23,7 +23,7 @@ async def get_index(active_project: str) -> Any:
     # Load in a thread to keep async loops clear
     return await asyncio.to_thread(_load)
 
-async def run_ingestion(active_project: str, project_path: str) -> Dict[str, str]:
+async def run_ingestion(active_project: str, project_path: str, exclude_dirs: list = None) -> Dict[str, str]:
     """Orchestrates the ingestion process for a specific project."""
     if not os.path.exists(project_path):
         raise FileNotFoundError(f"Project source path not found: {project_path}")
@@ -31,10 +31,10 @@ async def run_ingestion(active_project: str, project_path: str) -> Dict[str, str
     storage_dir = str(get_storage_path(active_project))
     
     # Run in a thread for CPU-intensive embedding
-    await asyncio.to_thread(sync_local_dir_custom, project_path, storage_dir)
+    await asyncio.to_thread(sync_local_dir_custom, project_path, storage_dir, exclude_dirs)
     
     return {
-        "last_sync": datetime.now().strftime("%H:%M:%S"),
+        "last_sync": datetime.utcnow().isoformat() + "Z",
         "status": "idle"
     }
 

--- a/src/aether/core/ingest.py
+++ b/src/aether/core/ingest.py
@@ -9,7 +9,7 @@ from aether.core.config import REQUIRED_EXTS, get_storage_path
 logger = logging.getLogger("aether.ingest")
 token = os.getenv("GITHUB_TOKEN")
 
-def sync_local_dir_custom(dir_path: str, storage_dir: str):
+def sync_local_dir_custom(dir_path: str, storage_dir: str, exclude_dirs: list = []):
     """
     Orchestrates the retrieval and indexing of a local directory into a specific storage folder.
     Uses incremental indexing (refresh) for efficiency.
@@ -19,11 +19,14 @@ def sync_local_dir_custom(dir_path: str, storage_dir: str):
     storage_path = Path(storage_dir)
     docstore_exists = (storage_path / "docstore.json").exists()
 
+    if exclude_dirs is None:
+        exclude_dirs = []
+
     reader = SimpleDirectoryReader(
         input_dir=dir_path,
         recursive=True,
         filename_as_id=True,
-        exclude=["node_modules", ".git", "__pycache__", "venv", ".venv", "storage"],
+        exclude=["node_modules", ".git", "__pycache__", "venv", ".venv", "storage"] + exclude_dirs,
         required_exts=REQUIRED_EXTS
     )
     

--- a/src/aether/core/watcher.py
+++ b/src/aether/core/watcher.py
@@ -10,10 +10,12 @@ from typing import Optional, Callable, List
 logger = logging.getLogger("aether.watcher")
 
 class ProjectWatcher(FileSystemEventHandler):
-    def __init__(self, loop, on_modified_callback: Callable, required_exts: List[str]):
+    def __init__(self, loop, on_modified_callback: Callable, required_exts: List[str], auto_sync: bool = False, on_change_detected_callback: Optional[Callable] = None):
         self.loop = loop
         self.on_modified_callback = on_modified_callback
         self.required_exts = required_exts
+        self.auto_sync = auto_sync
+        self.on_change_detected_callback = on_change_detected_callback
         self.last_triggered = 0
         self.debounce_seconds = 5
 
@@ -42,17 +44,76 @@ class ProjectWatcher(FileSystemEventHandler):
         current_time = time.time()
         if current_time - self.last_triggered > self.debounce_seconds:
             self.last_triggered = current_time
-            logger.info(f"Auto-sync triggered by {event.event_type}: {event.src_path}")
-            # Use the provided callback
-            asyncio.run_coroutine_threadsafe(self.on_modified_callback(), self.loop)
+            logger.info(f"Change detected by watcher: {event.event_type} on {event.src_path}")
+            if self.auto_sync:
+                # Use the provided callback
+                asyncio.run_coroutine_threadsafe(self.on_modified_callback(), self.loop)
+            else:
+                if self.on_change_detected_callback:
+                    self.loop.call_soon_threadsafe(self.on_change_detected_callback)
 
-def setup_watcher(path: str, loop: asyncio.AbstractEventLoop, on_modified_callback: Callable, required_exts: List[str]) -> Optional[Observer]:
+def setup_watcher(
+    path: str,
+    loop: asyncio.AbstractEventLoop,
+    on_modified_callback: Callable,
+    required_exts: List[str],
+    auto_sync: bool = False,
+    on_change_detected_callback: Optional[Callable] = None
+) -> Optional[Observer]:
     """Helper to initialize and start a watchdog observer."""
     if not path or not os.path.exists(path):
         return None
         
     observer = Observer()
-    handler = ProjectWatcher(loop, on_modified_callback, required_exts)
+    handler = ProjectWatcher(
+        loop=loop,
+        on_modified_callback=on_modified_callback,
+        required_exts=required_exts,
+        auto_sync=auto_sync,
+        on_change_detected_callback=on_change_detected_callback
+    )
     observer.schedule(handler, path, recursive=True)
     observer.start()
     return observer
+
+if __name__ == "__main__":
+    import unittest
+    from unittest.mock import MagicMock
+
+    class TestProjectWatcher(unittest.TestCase):
+        def test_handle_event_detect_only(self):
+            # Set up mock event
+            mock_event = MagicMock()
+            mock_event.is_directory = False
+            mock_event.src_path = "test_file.py"
+            mock_event.event_type = "modified"
+
+            # Set up mock loop and callback
+            mock_loop = MagicMock()
+            callback_called = False
+            
+            def mock_callback():
+                nonlocal callback_called
+                callback_called = True
+
+            # Instantiate ProjectWatcher with auto_sync=False
+            watcher = ProjectWatcher(
+                loop=mock_loop,
+                on_modified_callback=MagicMock(),
+                required_exts=[".py"],
+                auto_sync=False,
+                on_change_detected_callback=mock_callback
+            )
+
+            # Trigger handle_event
+            watcher._handle_event(mock_event)
+
+            # Verify that call_soon_threadsafe was called with mock_callback
+            mock_loop.call_soon_threadsafe.assert_called_once_with(mock_callback)
+
+    print("Running ProjectWatcher unit tests...")
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestProjectWatcher)
+    runner = unittest.TextTestRunner()
+    result = runner.run(suite)
+    if not result.wasSuccessful():
+        exit(1)


### PR DESCRIPTION
### Strategic Intent
Disable automatic ingestion triggering in Aether on file modifications to protect API quota. Instead, when the watcher detects file changes, it flags that there are pending changes in stats telemetry. Ingestion will only run when manually triggered. Additionally, allow project-specific directory exclusions to bypass indexing unwanted large nested directories.

### Technical Scope
- **Watcher (`watcher.py`)**: Updated callback mechanism to route events to a new `on_change_detected_callback` scheduled thread-safely via `loop.call_soon_threadsafe` when `auto_sync` is `False`.
- **API (`app.py`)**: Added `pending_changes` and `last_ingested` tracking, a `get_project_path` helper to route paths safely, and integrated the watcher state callbacks. Extended `add_project_endpoint` (POST `/projects`) to initialize `"exclude_dirs": []` in the project metadata.
- **Engine (`engine.py`)**: Adjusted ingestion to pass `exclude_dirs` through to the ingestion pipeline and format timestamps as UTC ISO strings.
- **Ingest (`ingest.py`)**: Modified `sync_local_dir_custom` to accept `exclude_dirs: list = []` and merge it with default reader exclusions inside `SimpleDirectoryReader`.
- **MCP Server (`mcp_server.py`)**: Prepended warnings to codebase queries when pending changes exist in the active project context.

### Verification Evidence
- Ran ProjectWatcher unit tests in `src/aether/core/watcher.py`, which passed successfully.
- Validated Python compilation of all five changed files to ensure syntax and import correctness.
- Manually tested project addition (`POST /projects`) and deletion endpoints to verify `"exclude_dirs": []` is written properly into `projects.json`.
- Queried uvicorn stats endpoint to confirm `auto_sync` defaults to `False`.

### Known Limitations
None.
