### PR TITLE
fix: resolve uvicorn observer deadlock during project switch. Ref #56

### DIFF
--- a/src/aether/api/app.py
+++ b/src/aether/api/app.py
@@ -81,12 +81,12 @@ def _save_quota(quota: dict):
 
 # --- Lifespan Management ---
 
-def restart_watcher():
+async def restart_watcher():
     global observer
     if observer:
         try:
             observer.stop()
-            observer.join()
+            await asyncio.to_thread(observer.join)
         except:
             pass
     
@@ -123,11 +123,11 @@ async def lifespan(app: FastAPI):
     sync_status["embed_calls_today"] = quota.get("embed_calls")
     sync_status["embed_limit"] = quota.get("embed_limit")
     
-    restart_watcher()
+    await restart_watcher()
     yield
     if observer:
         observer.stop()
-        observer.join()
+        await asyncio.to_thread(observer.join)
 
 app = FastAPI(title="Aether Context Engine", lifespan=lifespan)
 
@@ -236,7 +236,7 @@ async def switch_project(request: SwitchRequest):
     sync_status["embed_calls_today"] = quota.get("embed_calls")
     sync_status["embed_limit"] = quota.get("embed_limit")
     
-    restart_watcher()
+    await restart_watcher()
     return {"active": active_project}
 
 @app.get("/projects")


### PR DESCRIPTION
### Strategic Intent
Resolve a potential uvicorn event loop deadlock by converting the watchdog observer restart and stop/join operations to use non-blocking asynchronous threads. This prevents the server from hanging during project switching or lifespan shutdown.

### Technical Scope
- **API (`app.py`)**:
  - Converted `restart_watcher()` to an `async def`.
  - Replaced blocking synchronous `observer.join()` calls inside `restart_watcher()` and `lifespan()` shutdown with `await asyncio.to_thread(observer.join)`.
  - Updated all call sites of `restart_watcher()` to use `await` in the `lifespan()` startup and `/switch` project endpoint.

### Verification Evidence
- Verified Python compilation of `src/aether/api/app.py`.
- Watcher unit tests pass successfully.

### Known Limitations
None.
