### PR TITLE
refactor: add partial progress recovery to refresh path. Ref #46

### DIFF
--- a/src/aether/core/ingest.py
+++ b/src/aether/core/ingest.py
@@ -62,6 +62,9 @@ def sync_local_dir_custom(dir_path: str, storage_dir: str, exclude_dirs: list = 
             batch_count += 1
             # Sleep between batches to respect rate limits
             time.sleep(2)
+            
+            # Persist after each successful batch so progress is not lost on failure
+            index.storage_context.persist(persist_dir=storage_dir)
 
         updated_count = sum(refreshed_docs)
 


### PR DESCRIPTION
### Strategic Intent
Implement partial progress recovery inside the incremental refresh path of Aether's ingestion engine. This ensures that successfully refreshed batches are persisted incrementally, preventing the loss of embedding calls and progress in case of rate limit retry exhaustion in a subsequent batch.

### Technical Scope
- **Ingest (`ingest.py`)**:
  - Appended `index.storage_context.persist(persist_dir=storage_dir)` inside the batch refresh loop immediately after `batch_count += 1` and `time.sleep(2)`.

### Verification Evidence
- Verified Python compilation of `src/aether/core/ingest.py`.
- Watcher unit tests pass successfully.

### Known Limitations
None.
