### PR TITLE
docs: Item 8 — Aether documentation update

### DIFF
--- a/SESSION_BRIEF.md
+++ b/SESSION_BRIEF.md
@@ -1,0 +1,150 @@
+# SurvivalStack Session Onboarding Brief: Aether Context Engine
+**Date:** May 23, 2026
+
+This onboarding brief outlines the environment structure, current governance rules, system architecture, open backlog items, and directives for the Aether Context Engine following the session of May 23, 2026.
+
+---
+
+## 1. Environment Overview
+
+Aether is integrated within the multi-repository SurvivalStack product line. Below is the mapping of active repositories sourced from `registry.json`:
+
+| Product Line | Repository Name | Local Path | GitHub Repository | State |
+| :--- | :--- | :--- | :--- | :--- |
+| **Core** | `dotfiles` | `core/dotfiles` | `ChadHuckeba/Core-dotfiles` | Active |
+| **Core** | `huckos` | `core/HuckOS.C-137` | `ChadHuckeba/Core-HuckOS.C-137` | Active |
+| **SurvivalStack** | `vanguard` | `survivalstack/Vanguard` | `ChadHuckeba/SurvivalStack-Vanguard` | Active |
+| **SurvivalStack** | `cairn` | `survivalstack/cairn` | `ChadHuckeba/SurvivalStack-Cairn` | Active |
+| **SurvivalTools** | `aether` | `survivaltools/Aether` | `ChadHuckeba/SurvivalTools-Aether` | Active |
+| **SurvivalTools** | `atomic-crm` | `survivaltools/Atomic-CRM` | `ChadHuckeba/SurvivalTools-Atomic-CRM` | Active |
+| **HoundStack** | `wallboard` | `houndstack/Wallboard` | `ChadHuckeba/HoundStack-Wallboard` | Active |
+
+---
+
+## 2. Active Governance Framework
+
+Project governance is declared in `GEMINI.md` and coordinates local agent behavior with the Global Governance Architecture:
+
+*   **Precedence Mandate**: Global Policy (`~/.gemini/GEMINI.md`) supersedes Local Policy (`GEMINI.md`). Local policies add project-specific mandates but cannot override global mandates.
+*   **RAG-First Mandate**: AI agents MUST prioritize semantic codebase intelligence. Agents must use the `query_codebase` MCP tool before resorting to manual file-reading (`view_file` or `grep_search`).
+*   **Documentation Impact Assessment (DIA)**: Any code modifications affecting `src/aether/core/watcher.py` or `src/aether/core/ingest.py` require a synchronized sibling update to `docs/ENGINE.md`.
+*   **Telemetry Discipline**: All modules must initialize and use a hierarchical logger via `logging.getLogger("aether.<module>")`. Direct print statements for telemetry are strictly prohibited.
+*   **Audit Notice**: Governance is currently under audit and hardening (Work Items 9 and 10 are pending).
+
+---
+
+## 3. Aether System — Current State
+
+### 3.1 Architecture
+Aether is an asynchronous codebase context and query engine constructed using FastAPI and LlamaIndex. It uses the Google Gemini API (`gemini-embedding-001`) to generate embeddings and represent codebase repositories semantically as vector indices.
+
+### 3.2 API Endpoints
+Aether exposes the following HTTP endpoints:
+*   `GET /`: Serving the dashboard UI.
+*   `GET /manage`: Serving the project management UI.
+*   `GET /projects`: List all configured projects.
+*   `POST /projects`: Add a new project config (`name`, `path`).
+*   `DELETE /projects/{name}`: Delete a project configuration.
+*   `POST /switch`: Switch the active project context (`name`).
+*   `POST /query`: Query the active index via RAG (`prompt`).
+*   `POST /ingest`: Trigger an asynchronous background ingestion/sync task.
+*   `GET /stats`: Retrieve index size, file count, node list, memory metrics, and sync status.
+*   `POST /release`: Release the vector index from RAM.
+*   `GET /browse`: Interactive directory browser.
+
+### 3.3 Ingestion Pipeline
+The ingestion engine in `src/aether/core/ingest.py` orchestrates the local-to-storage synchronization:
+*   **Document ID Mapping**: Structured to use `filename_as_id=True` on the `SimpleDirectoryReader` for stable document tracking.
+*   **Targeted Exclusions**: Respects per-project directories listed under `exclude_dirs` in `projects.json`.
+*   **Batch Quotas**: Counted and tracked via `embed_calls_used` to feed the daily limit counter.
+*   **Incremental Recovery**: Employs incremental batch-level persistence (`index.storage_context.persist()`) inside both the full/initial indexing and refresh loop paths. This ensures that completed batches are saved immediately, preventing progress loss on rate-limit errors or timeouts.
+
+### 3.4 sync_status Structure
+The `/stats` response contains the following status metadata block:
+*   `status`: Status of the current ingestion context (`idle`, `syncing`, `quota_exceeded`, or `error: <msg>`).
+*   `last_sync`: ISO 8601 UTC timestamp of the last completed synchronization loop.
+*   `auto_sync`: Boolean representing whether file changes trigger auto-ingestion (default: `False`).
+*   `pending_changes`: Flagged `True` when file watch notifications occur but have not yet been synchronized.
+*   `last_ingested`: ISO 8601 UTC timestamp of last ingestion completed.
+*   `embed_calls_today`: Accumulation of embedding batches processed today.
+*   `embed_limit`: Configured ceiling for daily embedding batches (default: `900`).
+*   `embed_calls_used`: Count of embedding batches used in the most recent ingest run.
+
+### 3.5 MCP Integration
+Exposes FastMCP tools to client runtimes (e.g. `agy`):
+*   `query_codebase(prompt)`: Ask questions against the active project index.
+*   `refresh_index()`: Remote command triggering a background ingestion cycle.
+*   *Note:* The MCP configuration resolves `AETHER_BASE_URL` to `http://127.0.0.1:8000` to resolve local network routing issues.
+
+### 3.6 Current Index State
+As of May 23, 2026, all four active projects have had their indices successfully built/refreshed, and `last_ingested` timestamps are fully populated in `data/projects.json`:
+1.  **Vanguard** (Active, `/home/chadh/survivalstack/Vanguard`)
+2.  **Aether** (Active, `/home/chadh/survivaltools/Aether`)
+3.  **Wallboard** (Active, `/home/chadh/houndstack/Wallboard`)
+4.  **HuckOS.C-137** (Active, `/home/chadh/core/HuckOS.C-137`)
+
+### 3.7 Configuration Locations
+*   **Config Registry**: `data/projects.json` (fallback defaults in `src/aether/core/projects.py`).
+*   **Environment**: `.env` (contains API keys, port settings, and directories).
+*   **Quota Ledger**: `data/quota.json` (tracks daily API batch usage).
+
+---
+
+## 4. Open Work Items
+
+*   **Item 8: Write Aether documentation (ENGINE.md)** *(Next Active Item)*
+    *   Draft authoritative documentation covering Aether's internal logic, folder hierarchies, architecture, and module integrations.
+*   **Item 9: agy governance audit**
+    *   Conduct a compatibility review to ensure the agy agent strictly complies with local/global governance protocols, MEMORY.md boundaries, registry.json network definitions, and standardized VCS wrappers.
+*   **Item 10: Harden agy governance**
+    *   Implement robust behavior guards to prevent agy from autonomously initiating commands (like starting background servers) without manual authorization.
+*   **Backlog Issues (Backlog Status on Project Board #6):**
+    *   **Issue #58** (`chore`): Reconcile `load_projects()` fallback default to include newer schema fields (`last_ingested`, `exclude_dirs`).
+    *   **Issue #61** (`chore`, `governance`): Audit and prevent agy from starting Aether server autonomously without approval.
+    *   **Issue #62** (`chore`, `governance`): Reconcile `registry.json` keys, ports, and labels against Aether's actual state.
+    *   **Issue #63** (`chore`): Investigate adding build artifact directories (`.egg-info`, `dist`, etc.) to the default index exclusions.
+    *   **Issue #64** (`chore`): Investigate and reconcile `embed_calls_today` discrepancies resulting from model validation requests.
+
+---
+
+## 5. Pull Requests Merged This Session
+
+*   **PR #53** (`feat`): Added support for per-project directory exclusions (`exclude_dirs`) in the ingestion engine.
+*   **PR #55** (`feat`): Implemented a daily embedding quota guard and counter tracked in `data/quota.json`.
+*   **PR #57** (`fix`): Converted `restart_watcher()` to async and moved watchdog joins to threads, resolving Uvicorn server deadlock during project switches.
+*   **PR #60** (`refactor`): Added batch-level incremental persistence to the document refresh loop inside `sync_local_dir_custom` to prevent embedding loss.
+
+---
+
+## 6. Instructions for Next Session
+
+1.  **Immediate Focus**: Begin execution on **Item 8** by compiling the functional documentation for Aether in `docs/ENGINE.md`.
+2.  **Safety Directive**: Do NOT trigger any directory ingestion cycles without explicit operator confirmation.
+3.  **Service Control**: Do NOT start the Aether server process autonomously. Wait for manual operator startup and instruction.
+
+---
+
+## 7. Session Tracker State
+
+### Complete
+- Disable auto_sync, add pending_changes flag and exclude_dirs (PR #53)
+- Add daily embed quota guard (PR #55)
+- Uvicorn observer deadlock fix (PR #57)
+- Investigate automatic registry — no automatic registry confirmed
+- Fix Issue #46 — for/else RuntimeError partial progress recovery (PR #60)
+- Rebuild all indexes — Wallboard, HuckOS.C-137, Aether, Vanguard — all last_ingested populated
+
+### Active Next Session
+- Item 8: Write Aether documentation (ENGINE.md)
+
+### Governance (Pending Audit First)
+- Item 9: agy governance audit — GEMINI.md compatibility, MEMORY.md, registry.json, skill invocation syntax
+- Item 10: Harden agy governance — based on audit findings
+
+### Backlog
+- Issue #58: Update load_projects() fallback default schema
+- Issue #61: agy autonomously started Aether server without approval
+- Issue #62: Review and reconcile registry.json against current Aether state
+- Issue #63: Investigate egg-info and build artifacts in Aether index
+- Issue #64: Investigate embed_calls_today vs Google RPD dashboard discrepancy
+

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -28,8 +28,64 @@ Aether does not re-index the entire project on every change. Instead, it uses th
 Example Flow:
 `Syncing /path/to/project -> /path/to/aether/data/storage/project`
 
-## 3. Performance & Lazy Loading
+## 3. Lazy Loading & Memory
 Aether is optimized for a "Zero-Impact" background presence:
-*   **Sleep Mode:** The vector index is NOT loaded into RAM upon server start.
-*   **Lazy Loading:** The index is only pulled into memory during the first query of a session.
-*   **Release API:** The `/release` endpoint allows you to purge the index from RAM without stopping the server.
+*   **Startup Behavior:** The vector index is NOT loaded into RAM upon server startup.
+*   **Lazy Loading:** The index is only pulled into memory during the first `POST /query` of a session.
+*   **Release API:** The `/release` endpoint allows you to purge the index from RAM and trigger garbage collection (`gc.collect()`) without stopping the server.
+*   **Project Switching:** On a project switch via `POST /switch`, the active index is cleared and `gc.collect()` is called to completely release the prior index's memory.
+
+## 4. Ingestion Pipeline
+When a client sends a `POST /ingest` request, the ingestion process is executed in a background task thread through the following stages:
+
+1.  **Quota Verification**: The system loads the daily quota configuration via `_load_quota()`. If the total processed embedding calls exceed `embed_limit` (default: 900 batches/day), the ingestion halts immediately, transitioning the status to `quota_exceeded`.
+2.  **Task Launch**: If quota is available, the server sets `sync_status["status"] = "syncing"` and adds `run_ingestion_task` to the FastAPI `BackgroundTasks` queue.
+3.  **Engine Invocation**: The background task invokes `run_ingestion` in `engine.py`, which resolves the project storage directory and offloads the CPU/network-intensive work to a worker thread via `asyncio.to_thread`.
+4.  **Sync Execution**: The thread executes `sync_local_dir_custom()` in `ingest.py`. It instantiates a `SimpleDirectoryReader` configured with `filename_as_id=True` and directories to exclude (including defaults and project-specific `exclude_dirs`). The execution follows one of two paths:
+    *   **Initial Indexing (No docstore.json)**: Instantiates a clean `VectorStoreIndex([])` and inserts documents in batches of 5. It invokes `index.storage_context.persist(persist_dir=storage_dir)` after every successful batch and sleeps for 2 seconds.
+    *   **Incremental Refresh (docstore.json exists)**: Loads the existing index using `load_index_from_storage(storage_context)`. It iterates through documents in batches of 5, calling `index.refresh_ref_docs(batch)`. It persists the index to disk via `index.storage_context.persist(persist_dir=storage_dir)` after each batch and sleeps for 2 seconds. In case of 429 or 503 rate limiting responses from the Google API, a backoff sleep (15s, 30s, etc.) is applied with up to 5 retries. Stale files that no longer exist on disk are identified and deleted using `index.delete_ref_doc(doc_id)`.
+5.  **Final State Update**: After the loop finishes, the total `batch_count` (which represents the `embed_calls_used`) is returned. The task runner updates the active project's `last_ingested` timestamp in `projects.json`, increments the daily quota counter in `quota.json`, resets `sync_status["pending_changes"] = False`, and sets `sync_status["status"] = "idle"`.
+
+*Note: The per-batch `persist()` call is a key reliability feature. If a long ingestion is interrupted by a terminal rate-limit error or network timeout halfway through, all preceding successfully processed batches are saved to disk, preserving progress and avoiding the billing cost of re-embedding those files.*
+
+## 5. Data Flow
+Below is the metadata and file state read/write diagram for Aether operations:
+
+```mermaid
+graph TD
+    P_JSON[data/projects.json]
+    Q_JSON[data/quota.json]
+    STORAGE[data/storage/project_name/*]
+    STARTUP[lifespan startup]
+    INGEST[run_ingestion_task]
+    SWITCH[switch_project]
+    QUERY[query_endpoint]
+    STATS[get_stats]
+    STARTUP -->|Reads| P_JSON
+    STARTUP -->|Reads/Resets| Q_JSON
+    SWITCH -->|Reads| Q_JSON
+    INGEST -->|Reads/Writes| Q_JSON
+    INGEST -->|Reads/Writes| P_JSON
+    INGEST -->|Reads/Writes| STORAGE
+    QUERY -->|Reads| STORAGE
+    STATS -->|Reads| STORAGE
+```
+
+### Summary
+*   **Startup**: The server lifespan reads `projects.json` to load project paths, and `quota.json` to configure the daily limit (resetting the count if a new day has started).
+*   **Switching**: A project switch reads `quota.json` to refresh quota limits and restarts the file watcher.
+*   **Ingestion**: Reads and updates `quota.json` and `projects.json` (updating the sync timestamp). It reads from and writes to the `storage/` directory for the active project (loading the index state and persisting batches).
+*   **Querying & Stats**: Read the `storage/` directory to query the vector index and compute file metrics.
+
+## 6. Quota Management
+*   **embed_calls_today Tracking**: Embedding usage is tracked at the batch level (where 1 batch processes up to 5 documents).
+*   **Date-Reset Behavior**: `_load_quota()` parses `data/quota.json`. If the current date string (UTC) does not match the `"date"` attribute in the file, it automatically resets `embed_calls` to `0` and writes the reset ledger to disk.
+*   **Quota Ceiling**: A default limit of 900 batches/day is enforced. If an ingest task is triggered but the current count matches or exceeds the limit, Aether flags `quota_exceeded` and exits without making any API calls.
+*   **Strategic Improvement Plan**: See [docs/specs/QUOTA_EFFICIENCY.md](file:///home/chadh/survivaltools/Aether/docs/specs/QUOTA_EFFICIENCY.md) for specs on implementing adaptive throttling, debounce optimizations, and client-side caching.
+
+## 7. Known Inactive Code
+The following functions reside in `src/aether/core/ingest.py` but are currently inactive:
+*   `sync_local_dir(dir_path, project_name)`: A legacy wrapper for local directory syncing. This function is fully superseded by `sync_local_dir_custom()` which accepts explicit directory exclusion lists.
+*   `sync_github_repo(owner, repo, branch)`: A stub loader for retrieving and embedding GitHub repositories using `GithubRepositoryReader`. Currently, no API routes or watcher integrations are wired to use this feature.
+
+*Note: These functions are preserved in the codebase for potential future capability expansions and should not be removed.*

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -14,7 +14,7 @@ To add Aether as a tool in your agent's configuration:
     "command": "/path/to/aether/.venv/bin/python",
     "args": ["/path/to/aether/mcp_server.py"],
     "env": {
-      "AETHER_BASE_URL": "http://localhost:8000"
+      "AETHER_BASE_URL": "http://127.0.0.1:8000"
     }
   }
 }

--- a/docs/REGISTRY.md
+++ b/docs/REGISTRY.md
@@ -9,10 +9,14 @@ The source of truth for all tracked contexts. This file is automatically updated
 ### Schema
 ```json
 {
-    "Project1": "/absolute/path/to/project1",
-    "Project2": "/absolute/path/to/project2"
+    "ProjectName": {
+        "path": "/absolute/path/to/project",
+        "last_ingested": "2026-05-23T00:00:00Z",
+        "exclude_dirs": ["dist", ".egg-info"]
+    }
 }
 ```
+*Note: `exclude_dirs` is optional and defaults to an empty list `[]` if omitted.*
 
 ## 2. Security Boundary (`SAFE_ROOT`)
 To prevent accidental or malicious indexing of sensitive system directories, Aether enforces a `SAFE_ROOT` boundary.


### PR DESCRIPTION
## Summary
Completes Item 8. Updates existing documentation to reflect current codebase
state following the May 23 2026 session.

## Changes
- **ENGINE.md**: Added Ingestion Pipeline walkthrough, Data Flow diagram (Mermaid),
  Quota Management, Lazy Loading & Memory detail, and Known Inactive Code notice
  (sync_local_dir, sync_github_repo).
- **REGISTRY.md**: Updated project schema to reflect current multi-field structure
  including path, last_ingested, and exclude_dirs. Added note that exclude_dirs
  is optional.
- **INTEGRATIONS.md**: Corrected AETHER_BASE_URL in MCP config example from
  localhost to 127.0.0.1 to reflect known routing fix.
- **SESSION_BRIEF.md**: Moved from docs/ to project root. docs/ is for product
  documentation only. Session briefs belong at the project root.

## Related Issues
- Closes Item 8
- Ref #65 (watcher self-trigger — data/quota.json excluded from this commit intentionally)
- Ref #66 (dead code in ingest.py — documented in ENGINE.md, implementation decision pending)
