### PR TITLE
chore: remove retired atomic-crm repo from session brief

### DIFF
--- a/SESSION_BRIEF.md
+++ b/SESSION_BRIEF.md
@@ -16,7 +16,6 @@ Aether is integrated within the multi-repository SurvivalStack product line. Bel
 | **SurvivalStack** | `vanguard` | `survivalstack/Vanguard` | `ChadHuckeba/SurvivalStack-Vanguard` | Active |
 | **SurvivalStack** | `cairn` | `survivalstack/cairn` | `ChadHuckeba/SurvivalStack-Cairn` | Active |
 | **SurvivalTools** | `aether` | `survivaltools/Aether` | `ChadHuckeba/SurvivalTools-Aether` | Active |
-| **SurvivalTools** | `atomic-crm` | `survivaltools/Atomic-CRM` | `ChadHuckeba/SurvivalTools-Atomic-CRM` | Active |
 | **HoundStack** | `wallboard` | `houndstack/Wallboard` | `ChadHuckeba/HoundStack-Wallboard` | Active |
 
 ---


### PR DESCRIPTION
## Summary
This Pull Request removes references to the retired `atomic-crm` repository from the repository table in `SESSION_BRIEF.md`. This is part of the ongoing decommissioning of the Atomic CRM infrastructure.

## What Changed
- `SESSION_BRIEF.md`: Removed the entry for the `atomic-crm` repository from the multi-repository table.

## Verification
- Verified by inspecting `SESSION_BRIEF.md` layout and running `ssync` to ensure no other components are affected. This is verified under Tier 1 (manual verification).

## References
Ref #75
